### PR TITLE
changed the width of container div in portfolio page

### DIFF
--- a/Portfolio/style.css
+++ b/Portfolio/style.css
@@ -17,7 +17,8 @@ hr{
 .container{
     margin: 0 auto;
     margin-top: 50px;
-    width: 50%;
+    max-width: 700px;
+    width: 80%;
     display: grid;
     grid-template-columns: repeat(2,1fr);
 }


### PR DESCRIPTION
The width of container is 50% on every screen size. So that, the container width becomes too low for mobile screens.

So, I updated the `width`  property of container to 80% and added `max-width: 700px`.  Now, on larger devices, the width is max-width i.e. 700px. On mobile devices, the width will be 80% of device width.